### PR TITLE
fix(svg): center svgs within sidenavitems

### DIFF
--- a/src/style-items.scss
+++ b/src/style-items.scss
@@ -11,7 +11,6 @@
 @import './../node_modules/@aurodesignsystem/webcorestylesheets/src/core';
 
 svg {
-  top: -4px;
   width: var(--ds-size-300, $ds-size-300);
   /* stylelint-disable-next-line declaration-no-important */
   height: var(--ds-size-300, $ds-size-300) !important; // !important necc. to override inline styling


### PR DESCRIPTION
# Alaska Airlines Pull Request

**Resolves:** #17

## Summary:

Previously, SVGs were assigned a style top: -4px. This was causing the
SVGs to be misaligned within the parent. This commit removes the
top: -4px style from the SVGs.

## Type of change:

Please delete options that are not relevant.

- [x] Revision of an existing capability

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
